### PR TITLE
Cleaner crafting

### DIFF
--- a/code/modules/crafting/recipes.dm
+++ b/code/modules/crafting/recipes.dm
@@ -60,14 +60,7 @@
 	name = "campfire kit"
 	result = /obj/item/crafting/campfirekit
 	reqs = list(/obj/item/stack/sheet/mineral/wood = 15)
-	time = 80
-	category = CAT_MISC
-
-/datum/crafting_recipe/campfirekit
-	name = "set up campfire kit"
-	result = /obj/structure/campfire
-	reqs = list(/obj/item/crafting/campfirekit = 1)
-	time = 40
+	time = 120 // Around 12 seconds
 	category = CAT_MISC
 
 /datum/crafting_recipe/barrelfire

--- a/code/modules/fallout/obj/crafting.dm
+++ b/code/modules/fallout/obj/crafting.dm
@@ -168,5 +168,11 @@
 
 /obj/item/crafting/campfirekit
 	name = "campfire kit"
-	desc = "A small box filled with an assortment of wood and tender. Useful for quickly making a fire."
+	desc = "A small box filled with an assortment of wood and tender. Useful for quickly making a fire. Alt click to crate a camping fire."
 	icon_state = "lunchbox"
+
+/obj/item/crafting/campfirekit/AltClick(mob/user)
+	. = ..()
+	var/turf/T = get_turf(usr)
+	new /obj/structure/campfire(T)
+	return ..()


### PR DESCRIPTION

## Description
Makes the camp fire kit a in hand action rather then a crafting action

## Motivation and Context
Cleaner crafting and less menu hassle

## How Has This Been Tested?
nope
## Screenshots (if appropriate):
nya
## Changelog (necessary)
:cl:
tweak: makes camp fire kit be a in hand use rather then just crafting menu.
/:cl:
